### PR TITLE
fix: update relative URLs in documentation for consistency

### DIFF
--- a/docs/how-to/customize-bec/add-a-custom-nexus-structure.md
+++ b/docs/how-to/customize-bec/add-a-custom-nexus-structure.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: File writing
-    url: ../../learn/file-writer/index.md
+    url: learn/file-writer/index.md
   - title: File references from devices
-    url: ../../learn/file-writer/file-references.md
+    url: learn/file-writer/file-references.md
 ---
 
 # Add a custom NeXuS structure for the file writer

--- a/docs/how-to/customize-bec/index.md
+++ b/docs/how-to/customize-bec/index.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: File writing
-    url: ../../learn/file-writer/index.md
+    url: learn/file-writer/index.md
   - title: BEC Signals
-    url: ../../learn/devices/bec-signals.md
+    url: learn/devices/bec-signals.md
 ---
 
 # Customize BEC

--- a/docs/how-to/devices/add-a-pseudo-motor.md
+++ b/docs/how-to/devices/add-a-pseudo-motor.md
@@ -1,13 +1,13 @@
 ---
 related:
   - title: Add an EPICS motor
-    url: ../../how-to/devices/add-an-epics-motor.md
+    url: how-to/devices/add-an-epics-motor.md
   - title: Pseudo positioners
-    url: ../../learn/devices/pseudo-positioners.md
+    url: learn/devices/pseudo-positioners.md
   - title: EPICS motor classes
-    url: ../../learn/devices/epics-motors.md
+    url: learn/devices/epics-motors.md
   - title: Device config templates
-    url: ../../references/ophyd-devices/device-config-templates.md
+    url: references/ophyd-devices/device-config-templates.md
 ---
 
 # Add a Pseudo Positioner

--- a/docs/how-to/devices/add-an-epics-motor.md
+++ b/docs/how-to/devices/add-an-epics-motor.md
@@ -1,7 +1,5 @@
 ---
 related:
-  - title: Write a new Ophyd Class
-    url: how-to/devices/write-a-new-ophyd-class.html
   - title: Add a Pseudo Motor
     url: how-to/devices/add-a-pseudo-motor.html
   - title: EPICS Motor Classes

--- a/docs/how-to/devices/add-an-epics-signal.md
+++ b/docs/how-to/devices/add-an-epics-signal.md
@@ -1,9 +1,5 @@
 ---
 related:
-  - title: Config file
-    url: how-to/devices/config-file.html
-  - title: Write a new ophyd class
-    url: how-to/devices/write-a-new-ophyd-class.html
   - title: EPICS signal classes
     url: learn/devices/epics-signals.html
 ---

--- a/docs/how-to/devices/how-to-select-readout-priority.md
+++ b/docs/how-to/devices/how-to-select-readout-priority.md
@@ -1,13 +1,13 @@
 ---
 related:
   - title: Ophyd Kind in BEC
-    url: ../../learn/devices/ophyd-kinds.md
+    url: learn/devices/ophyd-kinds.md
   - title: ReadoutPriority in BEC
-    url: ../../learn/devices/readout-priority.md
+    url: learn/devices/readout-priority.md
   - title: Device Configuration in BEC
-    url: ../../learn/devices/device-config-in-bec.md
+    url: learn/devices/device-config-in-bec.md
   - title: How to select an Ophyd Kind
-    url: ../../how-to/devices/how-to-select-an-ophyd-kind.md
+    url: how-to/devices/how-to-select-an-ophyd-kind.md
 ---
 # Select a readout priority
 
@@ -67,7 +67,6 @@ Run a short scan 'line_scan' and confirm the device is read at the expected poin
 If you are interested in more details on how `readoutPriority` works in BEC, please check the learning material on the topic:
     
 !!! learn "[ReadoutPriority in BEC](../../learn/devices/readout-priority.md){ data-preview }"
-
 
 
 

--- a/docs/how-to/devices/index.md
+++ b/docs/how-to/devices/index.md
@@ -1,12 +1,3 @@
----
-related:
-  - title: Add a device
-    url: how-to/devices/add-a-device.html
-  - title: Config file
-    url: how-to/devices/config-file.html
-  - title: Write a new ophyd class
-    url: how-to/devices/write-a-new-ophyd-class.html
----
 
 # Devices
 

--- a/docs/how-to/general/connect-to-the-bec-vm-with-xfreerdp.md
+++ b/docs/how-to/general/connect-to-the-bec-vm-with-xfreerdp.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: Update BEC to a new version
-    url: ../../how-to/general/update-deployment.md
+    url: how-to/general/update-deployment.md
   - title: Operations and deployment
-    url: ../../learn/operations-and-deployment/index.md
+    url: learn/operations-and-deployment/index.md
 ---
 
 # Connect to the BEC VM with xfreerdp
@@ -65,4 +65,3 @@ When you are done:
 ## Common pitfalls
 - Using the wrong hostname for the VM.
 - Trying to connect from outside the PSI or beamline network.
-

--- a/docs/how-to/general/set-the-active-account-with-bec-set-account.md
+++ b/docs/how-to/general/set-the-active-account-with-bec-set-account.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: Connect to the BEC VM with xfreerdp
-    url: ../../how-to/general/connect-to-the-bec-vm-with-xfreerdp.md
+    url: how-to/general/connect-to-the-bec-vm-with-xfreerdp.md
   - title: Operations and deployment
-    url: ../../learn/operations-and-deployment/index.md
+    url: learn/operations-and-deployment/index.md
 ---
 
 # Set the Active Account with `bec-set-account`
@@ -60,4 +60,3 @@ Account p12345 has been set successfully.
 - Using a process-group value that does not match the required format `p` followed by exactly five digits.
 - Running the command outside the config directory that contains the wrapper.
 - Running the command on a machine that cannot reach the BEC server environment.
-

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,12 +1,3 @@
----
-related:
-  - title: Devices
-    url: how-to/devices/index.html
-  - title: Scans
-    url: how-to/scans/index.html
-  - title: Plugins
-    url: how-to/plugins/index.html
----
 
 # How to...
 

--- a/docs/how-to/scans/index.md
+++ b/docs/how-to/scans/index.md
@@ -1,12 +1,3 @@
----
-related:
-  - title: Step scan
-    url: how-to/scans/step-scan.html
-  - title: Fly scan
-    url: how-to/scans/fly-scan.html
-  - title: Data access
-    url: how-to/data-access/index.html
----
 
 # Scans
 

--- a/docs/learn/devices/bec-signals.md
+++ b/docs/learn/devices/bec-signals.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: Customize BEC
-    url: ../../how-to/customize-bec/index.md
+    url: how-to/customize-bec/index.md
   - title: File writing
-    url: ../../learn/file-writer/index.md
+    url: learn/file-writer/index.md
 ---
 
 # BEC Signals for Custom Devices

--- a/docs/learn/devices/device-config-in-bec.md
+++ b/docs/learn/devices/device-config-in-bec.md
@@ -1,15 +1,13 @@
 ---
 related:
   - title: Add an EPICS motor
-    url: ../../how-to/devices/add-an-epics-motor.md
-  - title: Write a new ophyd class
-    url: ../../how-to/devices/write-a-new-ophyd-class.html
+    url: how-to/devices/add-an-epics-motor.md
   - title: Add a pseudo motor
-    url: ../../how-to/devices/add-a-pseudo-motor.html
+    url: how-to/devices/add-a-pseudo-motor.html
   - title: ReadoutPriority in BEC
-    url: ../../learn/devices/readout-priority.md
+    url: learn/devices/readout-priority.md
   - title: Select a readout priority
-    url: ../../how-to/devices/how-to-select-readout-priority.md
+    url: how-to/devices/how-to-select-readout-priority.md
 ---
 
 # Device Configuration in BEC

--- a/docs/learn/devices/epics-motors.md
+++ b/docs/learn/devices/epics-motors.md
@@ -2,8 +2,6 @@
 related:
   - title: Add an EPICS motor
     url: how-to/devices/add-an-epics-motor.md
-  - title: Write a new ophyd class
-    url: how-to/devices/write-a-new-ophyd-class.html
   - title: Add a pseudo motor
     url: how-to/devices/add-a-pseudo-motor.html
 ---

--- a/docs/learn/devices/epics-motors.md
+++ b/docs/learn/devices/epics-motors.md
@@ -1,11 +1,11 @@
 ---
 related:
   - title: Add an EPICS motor
-    url: ../../how-to/devices/add-an-epics-motor.md
+    url: how-to/devices/add-an-epics-motor.md
   - title: Write a new ophyd class
-    url: ../../how-to/devices/write-a-new-ophyd-class.html
+    url: how-to/devices/write-a-new-ophyd-class.html
   - title: Add a pseudo motor
-    url: ../../how-to/devices/add-a-pseudo-motor.html
+    url: how-to/devices/add-a-pseudo-motor.html
 ---
 
 # EPICS Motor Variants
@@ -23,5 +23,4 @@ The right choice depends on your EPICS motor implementation.
 - If you have an ECMC-based motor, choose `ophyd_devices.EpicsMotorEC` to get ECMC-specific signals and checks.
 - If you have a VME user motor, choose `ophyd_devices.EpicsUserMotorVME` to get VME-specific signals and behavior.
 - For everything else, start with `ophyd_devices.EpicsMotor` as the normal default.
-
 

--- a/docs/learn/devices/epics-signals.md
+++ b/docs/learn/devices/epics-signals.md
@@ -1,7 +1,7 @@
 ---
 related:
   - title: Add an EPICS signal
-    url: ../../how-to/devices/add-an-epics-signal.md
+    url: how-to/devices/add-an-epics-signal.md
 ---
 
 # EPICS Signal Variants

--- a/docs/learn/devices/ophyd-kinds.md
+++ b/docs/learn/devices/ophyd-kinds.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: Introduction to ophyd
-    url: ../../learn/devices/introduction-to-ophyd.md
+    url: learn/devices/introduction-to-ophyd.md
   - title: Select an ophyd Kind for your device signals
-    url: ../../how-to/devices/how-to-select-an-ophyd-kind.md
+    url: how-to/devices/how-to-select-an-ophyd-kind.md
 ---
 
 # ophyd `Kind`

--- a/docs/learn/devices/pseudo-positioners.md
+++ b/docs/learn/devices/pseudo-positioners.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: Add a Pseudo Positioner
-    url: ../../how-to/devices/add-a-pseudo-motor.md
+    url: how-to/devices/add-a-pseudo-motor.md
   - title: EPICS motor classes
-    url: ../../learn/devices/epics-motors.md
+    url: learn/devices/epics-motors.md
 ---
 
 # Pseudo Positioners

--- a/docs/learn/file-writer/async-and-sync-writers.md
+++ b/docs/learn/file-writer/async-and-sync-writers.md
@@ -1,11 +1,11 @@
 ---
 related:
   - title: File writing
-    url: index.md
+    url: learn/file-writer/index.md
   - title: DefaultFormat and the default HDF5 layout
-    url: default-format.md
+    url: learn/file-writer/default-format.md
   - title: BEC Signals
-    url: ../../../learn/devices/bec-signals.md
+    url: learn/devices/bec-signals.md
 ---
 
 # Async and Sync File Writing

--- a/docs/learn/file-writer/default-format.md
+++ b/docs/learn/file-writer/default-format.md
@@ -1,11 +1,11 @@
 ---
 related:
   - title: File writing
-    url: ../../learn/file-writer/index.md
+    url: learn/file-writer/index.md
   - title: Customizing the file writer
-    url: ../../learn/file-writer/plugin-repository-integration.md
+    url: learn/file-writer/plugin-repository-integration.md
   - title: Add a custom NeXuS structure for the file writer
-    url: ../../how-to/customize-bec/add-a-custom-nexus-structure.md
+    url: how-to/customize-bec/add-a-custom-nexus-structure.md
 ---
 
 # Default HDF5 Layout
@@ -59,4 +59,3 @@ Some common operations include:
 - add datasets with `create_dataset(...)`
 - add data through links, either soft links to existing groups or datasets with `create_soft_link(...)` or external links to datasets in external files with `create_ext_link(...)`.
 - use helper methods such as `self.get_entry(...)` to access device values from scan data
-

--- a/docs/learn/file-writer/file-references.md
+++ b/docs/learn/file-writer/file-references.md
@@ -1,11 +1,11 @@
 ---
 related:
   - title: File writing
-    url: index.md
+    url: learn/file-writer/index.md
   - title: DefaultFormat and the default HDF5 layout
-    url: default-format.md
+    url: learn/file-writer/default-format.md
   - title: Add a custom NeXuS structure for the file writer
-    url: ../../how-to/customize-bec/add-a-custom-nexus-structure.md
+    url: how-to/customize-bec/add-a-custom-nexus-structure.md
 ---
 
 # File References from Devices

--- a/docs/learn/file-writer/index.md
+++ b/docs/learn/file-writer/index.md
@@ -1,7 +1,7 @@
 ---
 related:
   - title: Add a custom NeXuS structure for the file writer
-    url: ../../how-to/customize-bec/add-a-custom-nexus-structure.md
+    url: how-to/customize-bec/add-a-custom-nexus-structure.md
 ---
 
 # File Writing

--- a/docs/learn/file-writer/plugin-repository-integration.md
+++ b/docs/learn/file-writer/plugin-repository-integration.md
@@ -1,9 +1,9 @@
 ---
 related:
   - title: File writing
-    url: index.md
+    url: learn/file-writer/index.md
   - title: Add a custom NeXuS structure for the file writer
-    url: ../../how-to/customize-bec/add-a-custom-nexus-structure.md
+    url: how-to/customize-bec/add-a-custom-nexus-structure.md
 ---
 
 # Customizing the File Writer

--- a/docs/learn/file-writer/where-files-are-written.md
+++ b/docs/learn/file-writer/where-files-are-written.md
@@ -1,7 +1,7 @@
 ---
 related:
   - title: File writing
-    url: ../../learn/file-writer/index.md
+    url: learn/file-writer/index.md
 ---
 
 # Where Files Are Written
@@ -135,5 +135,4 @@ Users cannot escape this base path from the client side.
 - BEC checks that the resolved file path stays inside the configured base path.
 
 This prevents one user from writing into another user's directory.
-
 

--- a/docs/references/ophyd-devices/device-config-templates.md
+++ b/docs/references/ophyd-devices/device-config-templates.md
@@ -1,13 +1,13 @@
 ---
 related:
   - title: EpicsMotor, EpicsMotorEC, EpicsUserMotorVME
-    url: ../../learn/devices/epics-motors.html
+    url: learn/devices/epics-motors.html
   - title: EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
-    url: ../../learn/devices/epics-signals.html
+    url: learn/devices/epics-signals.html
   - title: Add an EPICS motor
-    url: ../../how-to/devices/add-an-epics-motor.html
+    url: how-to/devices/add-an-epics-motor.html
   - title: Add an EPICS signal
-    url: ../../how-to/devices/add-an-epics-signal.html
+    url: how-to/devices/add-an-epics-signal.html
 ---
 
 # Device config templates


### PR DESCRIPTION
I don't really understand why but sometimes, relative links are not resolved properly. However, we can just always use absolute links