### PR TITLE
Tests/extend tests and matchers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,8 @@ multi_line_output = 3
 include_trailing_comma = true
 known_first_party = ["bec_lib", "bec_server", "bec_ipython_client"]
 
-[tool.pytest]
-markers = ["expected_output"]
+[tool.pytest.ini_options]
+markers = [
+    "expected_output: attach an expected-output matcher to a docs snippet test",
+    "output_capture(mode): choose capture backend for a docs snippet test; supported: 'sys', 'fd', 'manual'",
+]

--- a/src/bec_docs_pymdown_extensions/matchers.py
+++ b/src/bec_docs_pymdown_extensions/matchers.py
@@ -1,10 +1,30 @@
+"""Matchers used by docs snippet tests.
+
+The expected-output marker serves two roles:
+1. The snippet preprocessor reads the matcher payload and renders the expected output in the docs.
+2. The pytest snippet suite compares the live result against that expected output.
+
+Keep matchers focused on how the output should be validated:
+- ``ContainsExpectedOutputMatcher`` for stable substrings
+- ``SimilarExpectedOutputMatcher`` for mostly-stable rich/text output with timestamps or spacing drift
+- ``SignalArrayOutputMatcher`` for structured numeric arrays with tolerances
+"""
+
 from abc import ABC, abstractmethod
 from difflib import Differ, SequenceMatcher
+import math
+import re
 
 from bec_docs_pymdown_extensions.snippet_preprocessor import PLACEHOLDER_TOKEN
 
 
 class ExpectedOutputMatcher(ABC):
+    """Base class for all docs output matchers.
+
+    ``expected_output`` is both the source of truth rendered into the published docs and
+    the reference text used by the pytest snippet suite.
+    """
+
     def __init__(self, expected_output: str) -> None:
         self._expected_output = expected_output
         self._differ = Differ()
@@ -22,14 +42,85 @@ class ExpectedOutputMatcher(ABC):
 
 
 class ContainsExpectedOutputMatcher(ExpectedOutputMatcher):
+    """Require the expected text to appear verbatim in the live output."""
+
     def check(self, output):
         return self._expected_output.replace(PLACEHOLDER_TOKEN, "") in output
 
 
 class SimilarExpectedOutputMatcher(ExpectedOutputMatcher):
+    """Require the live output to stay close to the documented example.
+
+    Use this for rich/IPython output where timestamps, padding, or small floating point
+    differences make exact matching too brittle.
+    """
+
     def __init__(self, expected_output: str, ratio: float = 0.9) -> None:
         super().__init__(expected_output)
         self._expected_ratio = ratio
 
     def check(self, output):
         return SequenceMatcher(None, self._expected_output, output).ratio() >= self._expected_ratio
+
+
+class SignalArrayOutputMatcher(ExpectedOutputMatcher):
+    """Validate scan-history style ``{'timestamp': array(...), 'value': array(...)}`` output.
+
+    Timestamps are intentionally treated structurally rather than literally. The matcher
+    checks that:
+    - both arrays are present
+    - the lengths match the documented example
+    - values are close within the configured tolerances
+    - timestamps are monotonic, if requested
+    """
+
+    def __init__(
+        self,
+        expected_output: str,
+        *,
+        value_atol: float = 0.05,
+        value_rtol: float = 0.0,
+        require_monotonic_timestamps: bool = True,
+    ) -> None:
+        super().__init__(expected_output)
+        self._value_atol = value_atol
+        self._value_rtol = value_rtol
+        self._require_monotonic_timestamps = require_monotonic_timestamps
+
+    @staticmethod
+    def _extract_series(text: str, key: str) -> list[float] | None:
+        match = re.search(rf"'{key}': array\(\[(.*?)\]\)", text, re.DOTALL)
+        if not match:
+            return None
+        numbers = re.findall(r"[-+]?\d*\.?\d+(?:e[-+]?\d+)?", match.group(1), re.IGNORECASE)
+        return [float(number) for number in numbers]
+
+    def check(self, output):
+        expected_timestamps = self._extract_series(self._expected_output, "timestamp")
+        expected_values = self._extract_series(self._expected_output, "value")
+        actual_timestamps = self._extract_series(output, "timestamp")
+        actual_values = self._extract_series(output, "value")
+
+        if not all(
+            series is not None
+            for series in (expected_timestamps, expected_values, actual_timestamps, actual_values)
+        ):
+            return False
+
+        if len(expected_timestamps) != len(actual_timestamps):
+            return False
+        if len(expected_values) != len(actual_values):
+            return False
+
+        for expected, actual in zip(expected_values, actual_values):
+            if not math.isclose(
+                expected, actual, rel_tol=self._value_rtol, abs_tol=self._value_atol
+            ):
+                return False
+
+        if self._require_monotonic_timestamps:
+            for earlier, later in zip(actual_timestamps, actual_timestamps[1:]):
+                if later < earlier:
+                    return False
+
+        return True

--- a/src/bec_docs_pymdown_extensions/matchers.py
+++ b/src/bec_docs_pymdown_extensions/matchers.py
@@ -32,10 +32,13 @@ class ExpectedOutputMatcher(ABC):
     @abstractmethod
     def check(self, output) -> bool: ...
 
+    def _normalized_expected_output(self) -> str:
+        return self._expected_output.replace(PLACEHOLDER_TOKEN, "")
+
     def diff(self, output) -> str:
         return "\n".join(
             self._differ.compare(
-                self._expected_output.replace(PLACEHOLDER_TOKEN, "").splitlines(),
+                self._normalized_expected_output().splitlines(),
                 output.splitlines(),
             )
         )
@@ -45,7 +48,7 @@ class ContainsExpectedOutputMatcher(ExpectedOutputMatcher):
     """Require the expected text to appear verbatim in the live output."""
 
     def check(self, output):
-        return self._expected_output.replace(PLACEHOLDER_TOKEN, "") in output
+        return self._normalized_expected_output() in output
 
 
 class SimilarExpectedOutputMatcher(ExpectedOutputMatcher):
@@ -60,7 +63,10 @@ class SimilarExpectedOutputMatcher(ExpectedOutputMatcher):
         self._expected_ratio = ratio
 
     def check(self, output):
-        return SequenceMatcher(None, self._expected_output, output).ratio() >= self._expected_ratio
+        return (
+            SequenceMatcher(None, self._normalized_expected_output(), output).ratio()
+            >= self._expected_ratio
+        )
 
 
 class SignalArrayOutputMatcher(ExpectedOutputMatcher):

--- a/src/bec_docs_pymdown_extensions/snippet_preprocessor.py
+++ b/src/bec_docs_pymdown_extensions/snippet_preprocessor.py
@@ -1,5 +1,6 @@
 import ast
 from pathlib import Path
+import re
 from textwrap import dedent
 
 from markdown.extensions import Extension
@@ -11,12 +12,29 @@ TEST_SNIPPET_DIR = Path(__file__).parent / "../../tests/snippet_tests/"
 PLACEHOLDER_TOKEN = "{{ placeholder }}"
 _F_STRING_TOKENS = {"PLACEHOLDER_TOKEN": PLACEHOLDER_TOKEN}
 _TOKEN_REPLACEMENTS = {PLACEHOLDER_TOKEN: "..."}
+_DOCS_DISPLAY_RE = re.compile(
+    r"^(?P<indent>\s*)print\((?P<expr>.+)\)\s*#\s*docs-display\s*$"
+)
+_DOCS_HIDE_RE = re.compile(r"^\s*.*#\s*docs-hide\s*$")
 
 
 def _replace_placeholders(s: str) -> str:
     for k, v in _TOKEN_REPLACEMENTS.items():
         s = s.replace(k, v)
     return s
+
+
+def _rewrite_docs_display_wrappers(code: str) -> str:
+    out_lines = []
+    for line in code.splitlines():
+        if _DOCS_HIDE_RE.match(line):
+            continue
+        match = _DOCS_DISPLAY_RE.match(line)
+        if match:
+            out_lines.append(f"{match.group('indent')}{match.group('expr')}")
+        else:
+            out_lines.append(line)
+    return "\n".join(out_lines)
 
 
 def _replacement(title: str, code: str, expected_output: str | None) -> list[str]:
@@ -97,11 +115,10 @@ def _transform_lines(lines: list[str]):
                 if (test_function := _extract_function(file_tree, test_name)) is None:
                     out_lines.append(f"Failed to find test {test_name} in {file}")
                     continue
-                code = "\n".join(
-                    file_text.splitlines()[test_function.lineno : test_function.end_lineno]
-                )
+                code = "\n".join(file_text.splitlines()[test_function.lineno : test_function.end_lineno])
+                code = _rewrite_docs_display_wrappers(dedent(code))
                 expected_value = _get_expected_value(file_tree, test_function)
-                out_lines.extend(_replacement(title, dedent(code), expected_value))
+                out_lines.extend(_replacement(title, code, expected_value))
             except Exception as e:
                 out_lines.append(f"Failed to process code snippet file: {file} \n {e}")
         else:

--- a/tests/extension_tests/preprocessor_test_data.py
+++ b/tests/extension_tests/preprocessor_test_data.py
@@ -1,8 +1,10 @@
 import pytest
 
 from bec_docs_pymdown_extensions.matchers import ContainsExpectedOutputMatcher
+from bec_docs_pymdown_extensions.snippet_preprocessor import PLACEHOLDER_TOKEN
 
 CONSTANT_STRING = "constant string"
+PLACEHOLDER_STRING = f"prefix {PLACEHOLDER_TOKEN} suffix"
 
 INCLUDED_VALUE = "interpolated"
 F_STRING = f"{INCLUDED_VALUE} f-string"
@@ -21,3 +23,15 @@ def transform_with_constant_string():
 def snippet_with_no_output():
     code = 3
     run_function()
+
+
+@pytest.mark.expected_output(ContainsExpectedOutputMatcher(CONSTANT_STRING))
+def snippet_with_docs_display_and_hidden_lines():
+    print(render_me())  # docs-display
+    helper = render_me()  # docs-hide
+    assert helper == "ok"  # docs-hide
+
+
+@pytest.mark.expected_output(ContainsExpectedOutputMatcher(PLACEHOLDER_STRING))
+def snippet_with_placeholder_output():
+    run_placeholder_demo()

--- a/tests/extension_tests/test_snippet_preprocessor.py
+++ b/tests/extension_tests/test_snippet_preprocessor.py
@@ -12,7 +12,14 @@ from .preprocessor_test_data import INCLUDED_VALUE
 def preprocessor_module():
     with (
         patch.object(snippet_extension, "TEST_SNIPPET_DIR", Path(__file__).parent),
-        patch.object(snippet_extension, "_F_STRING_TOKENS", {"INCLUDED_VALUE": INCLUDED_VALUE}),
+        patch.object(
+            snippet_extension,
+            "_F_STRING_TOKENS",
+            {
+                "INCLUDED_VALUE": INCLUDED_VALUE,
+                "PLACEHOLDER_TOKEN": snippet_extension.PLACEHOLDER_TOKEN,
+            },
+        ),
     ):
         yield snippet_extension
 
@@ -75,5 +82,45 @@ def test_snippet_with_no_output(preprocessor_module):
         "code = 3",
         "run_function()",
         "```",
+    ]
+    assert out_lines == expected_lines
+
+
+def test_snippet_rewrites_docs_display_and_hides_helper_lines(preprocessor_module):
+    in_lines = [
+        "--[]->[]--test_snippet--preprocessor_test_data.py:snippet_with_docs_display_and_hidden_lines:snippet with docs display"
+    ]
+    out_lines = preprocessor_module._transform_lines(in_lines)
+    expected_lines = [
+        "/// tab | :material-import: snippet with docs display",
+        "```python",
+        "render_me()",
+        "```",
+        "///",
+        "/// tab | :material-export: output",
+        "```",
+        "constant string",
+        "```",
+        "///",
+    ]
+    assert out_lines == expected_lines
+
+
+def test_snippet_replaces_placeholder_token_in_rendered_output(preprocessor_module):
+    in_lines = [
+        "--[]->[]--test_snippet--preprocessor_test_data.py:snippet_with_placeholder_output:snippet with placeholder output"
+    ]
+    out_lines = preprocessor_module._transform_lines(in_lines)
+    expected_lines = [
+        "/// tab | :material-import: snippet with placeholder output",
+        "```python",
+        "run_placeholder_demo()",
+        "```",
+        "///",
+        "/// tab | :material-export: output",
+        "```",
+        "prefix ... suffix",
+        "```",
+        "///",
     ]
     assert out_lines == expected_lines

--- a/tests/snippet_tests/conftest.py
+++ b/tests/snippet_tests/conftest.py
@@ -15,7 +15,7 @@ class TestSetupError(TypeError):
 
 
 @pytest.fixture(autouse=True)
-def expected_output_check(capsys, request: pytest.FixtureRequest):
+def expected_output_check(capfd, request: pytest.FixtureRequest):
     mark = request.node.get_closest_marker("expected_output")
     if mark is None:
         yield
@@ -23,13 +23,13 @@ def expected_output_check(capsys, request: pytest.FixtureRequest):
         if (len(mark.args) != 1) or not isinstance(matcher := mark.args[0], ExpectedOutputMatcher):
             raise TestSetupError("Mark your test with an expected output matcher!")
         yield
-        captured = capsys.readouterr()
+        captured = capfd.readouterr()
         if matcher.check(captured.out):
             pass
         else:
             # Retry after waiting to finish
             sleep(1)
-            captured = capsys.readouterr()
+            captured = capfd.readouterr()
             assert matcher.check(
                 captured.out
             ), f"Expected output matcher {type(matcher)} failed for test: {request.node.name}. Diff:\n{matcher.diff(captured.out)}"

--- a/tests/snippet_tests/conftest.py
+++ b/tests/snippet_tests/conftest.py
@@ -14,22 +14,99 @@ class TestSetupError(TypeError):
     """A failure to define the test correctly"""
 
 
-@pytest.fixture(autouse=True)
-def expected_output_check(capfd, request: pytest.FixtureRequest):
+def _get_expected_output_matcher(request: pytest.FixtureRequest) -> ExpectedOutputMatcher | None:
+    """Return the matcher declared on the test, if any."""
+
     mark = request.node.get_closest_marker("expected_output")
     if mark is None:
+        return None
+    if (len(mark.args) != 1) or not isinstance(matcher := mark.args[0], ExpectedOutputMatcher):
+        raise TestSetupError("Mark your test with an expected output matcher!")
+    return matcher
+
+
+@pytest.fixture
+def expected_output_matcher(request: pytest.FixtureRequest) -> ExpectedOutputMatcher | None:
+    """Expose the expected-output matcher to tests that validate output manually."""
+
+    return _get_expected_output_matcher(request)
+
+
+@pytest.fixture
+def assert_expected_output(expected_output_matcher: ExpectedOutputMatcher | None, request):
+    """Assert helper for tests that produce output outside normal pytest capture.
+
+    Pair this with ``@pytest.mark.output_capture("manual")`` when the test itself must
+    obtain the rendered output string, for example from IPython's pretty printer.
+    """
+
+    if expected_output_matcher is None:
+        raise TestSetupError(f"No expected_output marker defined for test {request.node.name}")
+
+    def _assert(output: str):
+        assert expected_output_matcher.check(
+            output
+        ), f"Expected output matcher {type(expected_output_matcher)} failed for test: {request.node.name}. Diff:\n{expected_output_matcher.diff(output)}"
+
+    return _assert
+
+
+@pytest.fixture
+def render_ipython_pretty():
+    """Render an object through the same ``_repr_pretty_`` path used in BEC IPython.
+
+    This is useful for snippet tests such as ``dev.samx`` where the documentation shows
+    IPython pretty-printed output rather than plain stdout.
+    """
+
+    def _render(obj) -> str:
+        class MockPrinter:
+            def __init__(self):
+                self.text_output = None
+                self.indentation = 0
+
+            def text(self, value):
+                self.text_output = value
+
+        printer = MockPrinter()
+        obj._repr_pretty_(printer, cycle=False)
+        return printer.text_output
+
+    return _render
+
+
+@pytest.fixture(autouse=True)
+def expected_output_check(request: pytest.FixtureRequest):
+    """Run the default expected-output assertion after each snippet test.
+
+    Capture modes:
+    - ``sys``: use ``capsys`` for normal Python stdout/stderr
+    - ``fd``: use ``capfd`` for live progress / lower-level writes
+    - ``manual``: skip automatic capture because the test validates the rendered output
+      itself via ``assert_expected_output(...)``
+    """
+
+    matcher = _get_expected_output_matcher(request)
+    if matcher is None:
         yield
     else:
-        if (len(mark.args) != 1) or not isinstance(matcher := mark.args[0], ExpectedOutputMatcher):
-            raise TestSetupError("Mark your test with an expected output matcher!")
+        capture_mark = request.node.get_closest_marker("output_capture")
+        capture_mode = capture_mark.args[0] if capture_mark else "sys"
+        capture_fixture_name = {"sys": "capsys", "fd": "capfd", "manual": None}.get(capture_mode)
+        if capture_fixture_name is None:
+            if capture_mode != "manual":
+                raise TestSetupError(f"Unsupported output capture mode: {capture_mode!r}")
+            yield
+            return
+        capture = request.getfixturevalue(capture_fixture_name)
         yield
-        captured = capfd.readouterr()
+        captured = capture.readouterr()
         if matcher.check(captured.out):
             pass
         else:
             # Retry after waiting to finish
             sleep(1)
-            captured = capfd.readouterr()
+            captured = capture.readouterr()
             assert matcher.check(
                 captured.out
             ), f"Expected output matcher {type(matcher)} failed for test: {request.node.name}. Diff:\n{matcher.diff(captured.out)}"

--- a/tests/snippet_tests/test_getting_started.py
+++ b/tests/snippet_tests/test_getting_started.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pprint import pformat
+from time import sleep
 
 import pytest
 
@@ -430,6 +431,13 @@ SCAN_HISTORY_SIGNAL_OUTPUT = """\
     SignalArrayOutputMatcher(SCAN_HISTORY_SIGNAL_OUTPUT, value_atol=0.05, value_rtol=0.01)
 )
 def test_scan_history_signal_arrays(bec):
-    scans.line_scan(dev.samx, -1, 1, steps=5, exp_time=0.1, relative=False)
-    latest = bec.history[-1]
+    scan_report = scans.line_scan(dev.samx, -1, 1, steps=5, exp_time=0.1, relative=False)
+    scan_report.wait(num_points=True, file_written=True)  # docs-hide
+    for _ in range(70):  # docs-hide
+        latest = bec.history.get_by_scan_id(scan_report.scan.scan_id)  # docs-hide
+        if latest is not None:  # docs-hide
+            break  # docs-hide
+        sleep(0.1)  # docs-hide
+    else:  # docs-hide
+        raise AssertionError("Timed out waiting for the scan to appear in bec.history")  # docs-hide
     print(latest.devices.samx.samx.read())  # docs-display

--- a/tests/snippet_tests/test_getting_started.py
+++ b/tests/snippet_tests/test_getting_started.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pprint import pformat
+
 import pytest
 
 from bec_docs_pymdown_extensions.matchers import (
     ContainsExpectedOutputMatcher,
+    SignalArrayOutputMatcher,
     SimilarExpectedOutputMatcher,
 )
 from bec_docs_pymdown_extensions.snippet_preprocessor import PLACEHOLDER_TOKEN
@@ -331,11 +334,102 @@ def test_show_all_devices(bec):
     dev.show_all()
 
 
+INSPECT_OUTPUT = """\
+              SimPositioner: samx
+ Enabled           True
+ Description
+ Read only         False
+ Software Trigger  False
+ Device class      ophyd_devices.SimPositioner
+ Readout Priority  baseline
+ Device tags       user motors
+ Limits            [-50, 50]
+
+                  Current Values
+ Signal                Value  Timestamp
+ samx                  0      2026-03-30 13:35:46
+ samx_setpoint         0      2026-03-30 13:35:46
+ samx_motor_is_moving  0      2026-03-30 13:35:46
+
+  Config Signals
+ Signal     Value
+ tolerance  0.01
+ """
+
+
 @pytest.mark.timeout(100)
-def test_inspect_samx(bec):
+@pytest.mark.output_capture("manual")
+@pytest.mark.expected_output(SimilarExpectedOutputMatcher(INSPECT_OUTPUT, ratio=0.6))
+def test_inspect_samx(bec, render_ipython_pretty, assert_expected_output):
     dev.samx
+    # ``dev.samx`` is displayed through IPython pretty-printing, not normal stdout capture.
+    rendered = render_ipython_pretty(dev.samx)  # docs-hide
+    assert_expected_output(rendered)  # docs-hide
+
+
+READ_OUTPUT = """\
+{'samx': {'value': 0, 'timestamp': 1774874622.037339},
+ 'samx_setpoint': {'value': 0, 'timestamp': 1774873374.7518551},
+ 'samx_motor_is_moving': {'value': 0, 'timestamp': 1774873374.751864}}
+"""
 
 
 @pytest.mark.timeout(100)
-def test_samx_read(bec):
+@pytest.mark.output_capture("manual")
+@pytest.mark.expected_output(SimilarExpectedOutputMatcher(READ_OUTPUT, ratio=0.75))
+def test_samx_read(bec, assert_expected_output):
     dev.samx.read()
+    # ``read()`` is documented as a formatted dict; validate that representation explicitly.
+    readback = dev.samx.read()  # docs-hide
+    assert_expected_output(pformat(readback, sort_dicts=False))  # docs-hide
+
+
+WM_OUTPUT = """\
+┏━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┓
+┃      ┃ readback ┃ setpoint ┃  limits   ┃
+┡━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━┩
+│ samx │  0.0000  │  0.0000  │ [-50, 50] │
+└──────┴──────────┴──────────┴───────────┘
+"""
+
+
+@pytest.mark.timeout(100)
+@pytest.mark.expected_output(ContainsExpectedOutputMatcher(WM_OUTPUT))
+def test_samx_wm(bec):
+    dev.samx.wm
+
+
+WM_MOVE_OUTPUT = """\
+PASSED [100%] samx:      0.00 ━━━━━━━━━━━━━━━       9.99 /      10.00 / 100 % 0:00:00 0:00:00
+┏━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┓
+┃      ┃ readback ┃ setpoint ┃  limits   ┃
+┡━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━┩
+│ samx │ 10.0000  │ 10.0000  │ [-50, 50] │
+└──────┴──────────┴──────────┴───────────┘
+"""
+
+
+@pytest.mark.timeout(100)
+@pytest.mark.output_capture("fd")
+@pytest.mark.expected_output(SimilarExpectedOutputMatcher(WM_MOVE_OUTPUT, ratio=0.7))
+def test_samx_blocking_move(bec):
+    scans.umv(dev.samx, 10, relative=False)  # make the move
+    dev.samx.wm  # check the move is done
+
+
+SCAN_HISTORY_SIGNAL_OUTPUT = """\
+{'timestamp': array([1.77496343e+09, 1.77496343e+09, 1.77496343e+09, 1.77496344e+09,
+        1.77496344e+09]),
+ 'value': array([-0.99140924, -0.49119309, -0.00282538,  0.49814051,  0.99329906])}
+"""
+
+
+@pytest.mark.timeout(100)
+@pytest.mark.output_capture("fd")
+@pytest.mark.expected_output(
+    SignalArrayOutputMatcher(SCAN_HISTORY_SIGNAL_OUTPUT, value_atol=0.05, value_rtol=0.01)
+)
+def test_scan_history_signal_arrays(bec):
+    scans.line_scan(dev.samx, -1, 1, steps=5, exp_time=0.1, relative=False)
+    latest = bec.history[-1]
+    print(latest.devices.samx.samx.read())  # docs-display


### PR DESCRIPTION
- added structural matching for scan-history signal arrays with tolerance-based value checks
- introduced per-test capture modes: `sys`, `fd`, and `manual`
- added helpers for manual validation of IPython pretty-printed output
- kept docs snippets clean via # docs-hide while still asserting rendered output in tests
- documented when to use each matcher and capture mode in the matcher and fixture modules